### PR TITLE
Website/keep accent colours when page refreshes

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -19,10 +19,10 @@ npm create svelte@latest my-app
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
 
 ```bash
-npm run dev
+npm run serve
 
 # or start the server and open the app in a new browser tab
-npm run dev -- --open
+npm run serve -- --open
 ```
 
 ## Building

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "vite dev",
+		"serve": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/website/src/lib/components/accent_selector.svelte
+++ b/website/src/lib/components/accent_selector.svelte
@@ -16,13 +16,21 @@
 
 	$: {
 		const pageColour = $page.url.searchParams.get('colour')
-		if (selectedColour && selectedColour !== pageColour) {
+		if (selectedColour !== pageColour) {
 			$page.url.searchParams.set('colour', selectedColour)
 			goto($page.url, { replaceState: true })
 		}
 	}
 
 	$: dispatch('accent', selectedColour)
+
+	function resetSelectedColour(
+		event: MouseEvent & { currentTarget: EventTarget & HTMLInputElement },
+	) {
+		if (event.currentTarget.value === selectedColour) {
+			selectedColour = ''
+		}
+	}
 </script>
 
 <fieldset name="accent">
@@ -37,6 +45,7 @@
 				name="colours"
 				value={colour}
 				id="colours-{colour}"
+				on:click={resetSelectedColour}
 				hidden
 			/>
 		</label>

--- a/website/src/lib/components/accent_selector.svelte
+++ b/website/src/lib/components/accent_selector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte'
+	import { createEventDispatcher, onMount } from 'svelte'
 	import { goto } from '$app/navigation'
 	import { page } from '$app/stores'
 
@@ -7,17 +7,22 @@
 	const colours = ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'purple', 'pink']
 	export let selectedColour: string
 
-	$: dispatch('accent', selectedColour)
+	onMount(() => {
+		const pageColour = $page.url.searchParams.get('colour')
+		if (pageColour) {
+			selectedColour = pageColour
+		}
+	})
 
 	$: {
 		const pageColour = $page.url.searchParams.get('colour')
-		if (pageColour && !selectedColour) {
-			selectedColour = pageColour
-		} else if (selectedColour && selectedColour !== pageColour) {
+		if (selectedColour && selectedColour !== pageColour) {
 			$page.url.searchParams.set('colour', selectedColour)
 			goto($page.url, { replaceState: true })
 		}
 	}
+
+	$: dispatch('accent', selectedColour)
 </script>
 
 <fieldset name="accent">

--- a/website/src/routes/buttons/+page.svelte
+++ b/website/src/routes/buttons/+page.svelte
@@ -40,7 +40,7 @@
 
 		<p class="body-4">Click on a button to copy it's classes.</p>
 
-		<AccentSelector {selectedColour} on:accent={(ev) => (selectedColour = ev.detail)} />
+		<AccentSelector updateColour={(newColour) => (selectedColour = newColour)} />
 	</TokenDescription>
 
 	<h2 class="heading-4">Filled</h2>

--- a/website/src/routes/checkboxes/+page.svelte
+++ b/website/src/routes/checkboxes/+page.svelte
@@ -12,7 +12,7 @@
 			or <code>radio-*</code> to the appropriate input.
 		</p>
 
-		<AccentSelector {selectedColour} on:accent={(ev) => (selectedColour = ev.detail)} />
+		<AccentSelector updateColour={(newColour) => (selectedColour = newColour)} />
 	</TokenDescription>
 
 	<fieldset name="checkbox">

--- a/website/src/routes/inputs/+page.svelte
+++ b/website/src/routes/inputs/+page.svelte
@@ -12,7 +12,7 @@
 			colour then the accent colours with be greyscale.
 		</p>
 
-		<AccentSelector {selectedColour} on:accent={(ev) => (selectedColour = ev.detail)} />
+		<AccentSelector updateColour={(newColour) => (selectedColour = newColour)} />
 	</TokenDescription>
 
 	<label for="input1" class="label-1">


### PR DESCRIPTION
If you are on a page with the accent colour selector the colour will now stay if you refresh the page, or if you load a page with the query param then you will see that colour straight away!

Oh also the script to start the dev server has changed from `npm run dev` to `npm run serve`